### PR TITLE
Long running operation for Clusters_Delete

### DIFF
--- a/specification/vmwarevirtustream/resource-manager/Microsoft.VMwareVirtustream/preview/2019-08-09-preview/vmwarevirtustream.json
+++ b/specification/vmwarevirtustream/resource-manager/Microsoft.VMwareVirtustream/preview/2019-08-09-preview/vmwarevirtustream.json
@@ -607,6 +607,7 @@
       },
       "delete": {
         "operationId": "Clusters_Delete",
+        "x-ms-long-running-operation": true,
         "tags": [
           "Clusters"
         ],


### PR DESCRIPTION
Clusters_Delete should be a long running operation so the client can poll the operation status.